### PR TITLE
Removed obsolete 'cql' package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from setuptools import setup
 setup(
     name="cqlsh",
     install_requires=[
-        "cql",
         "cassandra-driver",
         "six",
     ],


### PR DESCRIPTION
This was an old (2012) python driver for CQL which has been replaced by the DataStax cassandra-driver.

See https://pypi.org/project/cql and https://code.google.com/archive/a/apache-extras.org/p/cassandra-dbapi2
#4 