### PR TITLE
Revert "Release 6.1.0, drop Python 2 support"

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,6 @@ Unfortunately the Cassandra project does not always increment the `cqlsh` versio
 release we need to document not only the `cqlsh` version but also the `cassandra` version in which it
 shipped.
 
-#### 6.1.0 (Unreleased)
-
-This packages `cqlsh` `6.1.0` from [Cassandra 4.1](https://github.com/apache/cassandra/blob/cassandra-4.1.0/bin/cqlsh.py):
-* Requires Python 3.6+.
-* Although this is pulled from a Cassandra `4.x` release, it should generally work against Cassandra `3.x` clusters without needing to set any flags.
-
 #### 6.0.1 (Jan 18, 2022)
 
 The actual source code is identical to the `cqlsh` `6.0.0` release, except it's now packaged as

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,8 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
@@ -25,7 +27,7 @@ classifiers =
 
 [options]
 packages = cqlsh, cqlshlib
-python_requires = >=3.6
+python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*
 
 # Dependencies are in setup.py for GitHub's dependency graph.
 


### PR DESCRIPTION
Reverts jeffwidman/cqlsh#16

This was merged prematurely, the outstanding items listed in https://github.com/jeffwidman/cqlsh/pull/16#issue-1181544375 aren't complete yet...