### PR TITLE
Release 6.1.0, drop Python 2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ Unfortunately the Cassandra project does not always increment the `cqlsh` versio
 release we need to document not only the `cqlsh` version but also the `cassandra` version in which it
 shipped.
 
+#### 6.1.0 (Unreleased)
+
+This packages `cqlsh` `6.1.0` from [Cassandra 4.1](https://github.com/apache/cassandra/blob/cassandra-4.1.0/bin/cqlsh.py):
+* Requires Python 3.6+.
+* Although this is pulled from a Cassandra `4.x` release, it should generally work against Cassandra `3.x` clusters without needing to set any flags.
+
 #### 6.0.1 (Jan 18, 2022)
 
 The actual source code is identical to the `cqlsh` `6.0.0` release, except it's now packaged as

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,8 +17,6 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
@@ -27,7 +25,7 @@ classifiers =
 
 [options]
 packages = cqlsh, cqlshlib
-python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*
+python_requires = >=3.6
 
 # Dependencies are in setup.py for GitHub's dependency graph.
 


### PR DESCRIPTION
This is another try on #16, but hopefully we don't jump the gun this time.

As a byproduct of this, `cassandra` `4.1` bumped the `cqlsh` version to
`6.1.0` and also dropped Python 2 support (along with many other
cleanups).

TODO:
- [x]  bump underlying `cqlsh` and `cqlshlib` python code once `cassandra` `4.1` drops (https://github.com/jeffwidman/cqlsh/pull/21)
- [x] update PyPI classifiers to drop Python 2
- [ ] update release date on the `Readme` of `6.1.0` from `unreleased` to whatever day this gets merged/pushed to PyPI.

Fix https://github.com/jeffwidman/cqlsh/issues/13