### PR TITLE
Remove metadata from pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,5 @@
----
-name: Default template
-about: Point people toward upstream cqlsh
-title: ''
-labels: ''
-assignees: ''
-
----
-
 Because this is a repackaging of `cqlsh` from the official [Cassandra repo](https://gitbox.apache.org/repos/asf/cassandra.git), **only issues / PRs related to PyPI packaging should be opened against this repo**.
 
 If you would like to contribute to `cqlsh` itself, [find out more information here](https://github.com/apache/cassandra/blob/trunk/CONTRIBUTING.md).
+
+Otherwise, if your PR is still appropriate for this repo, then replace this warning with your PR description. And thanks for improving `cqlsh`!


### PR DESCRIPTION
Pull request templates don't support specifying metadata like labels etc. Whatever is in the file will get copied to the PR body. So delete the metadata from here.