### PR TITLE
Remove unused `six` from `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,5 @@ setup(
     name="cqlsh",
     install_requires=[
         "cassandra-driver",
-        "six",
     ],
 )


### PR DESCRIPTION
This was removed from upstream code, but we forgot to update `setup.py` when we pulled that in.