### PR TITLE
Update pyproject.toml with Homepage project URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
 ]
 
 [project.urls]
+Homepage = "https://github.com/jeffwidman/cqlsh"
 Documentation = "https://cassandra.apache.org/doc/latest/tools/cqlsh.html"
 Issues = "https://github.com/jeffwidman/cqlsh/issues"
 Changelog = "https://github.com/jeffwidman/cqlsh#changelog"


### PR DESCRIPTION
Because this is a repackaging of `cqlsh` from the official [Cassandra repo](https://gitbox.apache.org/repos/asf/cassandra.git), **only issues / PRs related to PyPI packaging should be opened against this repo**.

If you would like to contribute to `cqlsh` itself, [find out more information here](https://github.com/apache/cassandra/blob/trunk/CONTRIBUTING.md).

Otherwise, if your PR is still appropriate for this repo, then replace this warning with your PR description. And thanks for improving `cqlsh`!
